### PR TITLE
Allow querying for active games

### DIFF
--- a/FungusToast.postman_collection.json
+++ b/FungusToast.postman_collection.json
@@ -1,0 +1,117 @@
+{
+	"info": {
+		"_postman_id": "0592e1e2-1d07-4c74-990a-08306d4cae06",
+		"name": "Fungus Toast",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get User Games",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:4000/api/users/2/games?active=true",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "4000",
+					"path": [
+						"api",
+						"users",
+						"2",
+						"games"
+					],
+					"query": [
+						{
+							"key": "active",
+							"value": "true"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create Game",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"userName\": \"Fungus Amungus\",\n\t\"numberOfHumanPlayers\": 1,\n\t\"numberOfAiPlayers\": 2\n}"
+				},
+				"url": {
+					"raw": "http://localhost:4000/api/games",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "4000",
+					"path": [
+						"api",
+						"games"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Upgrade Skills",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"skillUpgrades\": [\n\t\t{\"id\": 1, \"pointsSpent\": 1},\n\t\t{\"id\": 3, \"pointsSpent\": 3}\n\t]\n}"
+				},
+				"url": {
+					"raw": "http://localhost:4000/api/games/3/players/4/skills",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "4000",
+					"path": [
+						"api",
+						"games",
+						"3",
+						"players",
+						"4",
+						"skills"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/lib/fungus_toast/games/games.ex
+++ b/lib/fungus_toast/games/games.ex
@@ -25,6 +25,28 @@ defmodule FungusToast.Games do
   end
 
   @doc """
+  Returns a list of games for a given user. The "active" parameter determines which games are returned
+  """
+  def list_games_for_user(%User{} = user), do: list_games_for_user(user, ["Started", "Not Started"])
+  def list_games_for_user(%User{} = user, true), do: list_games_for_user(user, ["Started"])
+  def list_games_for_user(%User{} = user, false), do: list_games_for_user(user)
+  def list_games_for_user(%User{} = user, nil), do: list_games_for_user(user)
+  def list_games_for_user(%User{} = user, statuses) when is_list(statuses) do
+    user = user |> Repo.preload(players: :game)
+    games = user.players
+            |> Enum.map(fn p -> p.game end)
+            |> Enum.filter(fn g -> Enum.member?(statuses, g.status) end)
+    {:ok, games}
+  end
+  def list_games_for_user(user_id, active) when is_boolean(active) do
+    user = Accounts.get_user!(user_id)
+    list_games_for_user(user, active)
+  end
+  def list_games_for_user(_, _) do
+    {:error, :bad_request}
+  end
+
+  @doc """
   Gets a single game.
 
   Raises `Ecto.NoResultsError` if the Active game does not exist.

--- a/lib/fungus_toast_web/controllers/game_controller.ex
+++ b/lib/fungus_toast_web/controllers/game_controller.ex
@@ -5,6 +5,16 @@ defmodule FungusToastWeb.GameController do
 
   action_fallback FungusToastWeb.FallbackController
 
+  def index(conn, params) do
+    user_id = Map.get(params, "user_id")
+    active = Map.get(params, "active", "false") |> active?()
+
+    with {:ok, games} <- Games.list_games_for_user(user_id, active) do
+      games = games |> FungusToast.Repo.preload([:rounds, players: [skills: :skill]])
+      render(conn, "index.json", games: games)
+    end
+  end
+
   def show(conn, %{"id" => id}) do
     game =
       Games.get_game!(id) |> FungusToast.Repo.preload([:rounds, players: [skills: :skill]])
@@ -19,4 +29,9 @@ defmodule FungusToastWeb.GameController do
       |> render("show.json", game: game)
     end
   end
+
+  defp active?("1"), do: true
+  defp active?("true"), do: true
+  defp active?("false"), do: false
+  defp active?(_), do: :error
 end

--- a/lib/fungus_toast_web/controllers/game_controller.ex
+++ b/lib/fungus_toast_web/controllers/game_controller.ex
@@ -33,6 +33,7 @@ defmodule FungusToastWeb.GameController do
 
   defp active?("1"), do: true
   defp active?("true"), do: true
+  defp active?("0"), do: false
   defp active?("false"), do: false
   defp active?(_), do: :error
 end

--- a/lib/fungus_toast_web/controllers/game_controller.ex
+++ b/lib/fungus_toast_web/controllers/game_controller.ex
@@ -10,20 +10,21 @@ defmodule FungusToastWeb.GameController do
     active = Map.get(params, "active", "false") |> active?()
 
     with {:ok, games} <- Games.list_games_for_user(user_id, active) do
-      games = games |> FungusToast.Repo.preload([:rounds, players: [skills: :skill]])
+      games = games
+              |> Games.preload_for_games()
+              |> Games.decorate_games()
       render(conn, "index.json", games: games)
     end
   end
 
   def show(conn, %{"id" => id}) do
-    game =
-      Games.get_game!(id) |> FungusToast.Repo.preload([:rounds, players: [skills: :skill]])
+    game = Games.get_game!(id) |> Games.preload_for_games()
     render(conn, "show.json", game: game)
   end
 
   def create(conn, game) do
     with {:ok, game} <- Games.create_game(game) do
-      game = game |> FungusToast.Repo.preload([:rounds, players: [skills: :skill]])
+      game = game |> Games.preload_for_games()
       conn
       |> put_status(:created)
       |> render("show.json", game: game)

--- a/lib/fungus_toast_web/controllers/player_skill_controller.ex
+++ b/lib/fungus_toast_web/controllers/player_skill_controller.ex
@@ -18,11 +18,7 @@ defmodule FungusToastWeb.PlayerSkillController do
       |> Games.update_player(%{mutation_points: player.mutation_points - spent_points})
 
       game = Games.get_game!(game_id) |> FungusToast.Repo.preload(:players)
-      new_round =
-        game.players
-        |> Enum.filter(fn p -> Map.get(p, :human) end)
-        |> Enum.all?(fn p -> Map.get(p, :mutation_points) == 0 end)
-
+      new_round = Games.next_round_available?(game)
       # How can we do this with Jason? It wants a struct and we don't have one here
       json(conn, %{nextRoundAvailable: new_round})
     end

--- a/lib/fungus_toast_web/router.ex
+++ b/lib/fungus_toast_web/router.ex
@@ -31,6 +31,8 @@ defmodule FungusToastWeb.Router do
       resources "/rounds", RoundController, only: [:show, :create]
     end
 
-    resources "/users", UserController, except: [:new, :edit]
+    resources "/users", UserController, except: [:new, :edit] do
+      get "/games", GameController, :index, as: :game
+    end
   end
 end

--- a/lib/fungus_toast_web/views/game_view.ex
+++ b/lib/fungus_toast_web/views/game_view.ex
@@ -1,5 +1,14 @@
 defmodule FungusToastWeb.GameView do
   use FungusToastWeb, :view
+  alias FungusToastWeb.GameView
 
-  def render("show.json", %{game: game}), do: map_from(game)
+  def render("index.json", %{games: games}) do
+    render_many(games, GameView, "game.json")
+  end
+
+  def render("show.json", %{game: game}) do
+    render_one(game, GameView, "game.json")
+  end
+
+  def render("game.json", %{game: game}), do: map_from(game)
 end


### PR DESCRIPTION
Some assumptions I made:
- A game is only active if it is in the `Started` state
- Both `true` and `1` should be capable of returning games in the `Started` state
- If no `active` param is passed in, or the value is `false` (or `0`), return all games regardless of state 
- Any other value for `active` should return a `"Bad Request"`

Closes #19 