### PR TITLE
split out active skills

### DIFF
--- a/lib/fungus_toast/games/active_cell_change.ex
+++ b/lib/fungus_toast/games/active_cell_change.ex
@@ -4,7 +4,7 @@ defmodule FungusToast.Games.ActiveCellChange do
 
   @required_attrs [
     :player_id,
-    :skill_id,
+    :active_skill_id,
     :cell_indexes
   ]
 
@@ -12,7 +12,7 @@ defmodule FungusToast.Games.ActiveCellChange do
   @primary_key false
   embedded_schema do
     field :player_id, :integer, null: false
-    field :skill_id, :integer, null: false
+    field :active_skill_id, :integer, null: false
     field :cell_indexes, {:array, :integer}, on_replace: :delete
   end
 

--- a/lib/fungus_toast/games/active_skill.ex
+++ b/lib/fungus_toast/games/active_skill.ex
@@ -1,20 +1,20 @@
-defmodule FungusToast.Games.Skill do
+defmodule FungusToast.Games.ActiveSkill do
   use Ecto.Schema
   import Ecto.Changeset
 
   @attrs [
     :name,
     :description,
-    :up_is_good
+    :number_of_toast_changes,
+    :minimum_round
   ]
 
   @derive {Jason.Encoder, only: [:id] ++ @attrs}
 
-  schema "skills" do
+  schema "active_skills" do
     field :description, :string, size: 512
-    field :increase_per_point, :float
+    field :number_of_toast_changes, :integer, default: 0
     field :name, :string, size: 64
-    field :up_is_good, :boolean
     field :minimum_round, :integer, default: 0
 
     timestamps()
@@ -23,8 +23,8 @@ defmodule FungusToast.Games.Skill do
   @doc false
   def changeset(skill, attrs) do
     skill
-    |> cast(attrs, [:name, :description, :increase_per_point, :up_is_good, :minimum_round])
-    |> validate_required([:name, :description, :increase_per_point])
+    |> cast(attrs, [:name, :description, :number_of_toast_changes, :minimum_round])
+    |> validate_required([:name, :description, :number_of_toast_changes, :minimum_round])
     |> validate_length(:name, max: 64)
     |> validate_length(:description, max: 512)
     |> unique_constraint(:name)

--- a/lib/fungus_toast/games/games.ex
+++ b/lib/fungus_toast/games/games.ex
@@ -8,7 +8,7 @@ defmodule FungusToast.Games do
   alias FungusToast.{Repo, Accounts, Players, PlayerSkills, Rounds, ActiveCellChanges}
   alias FungusToast.Accounts.User
 
-  alias FungusToast.Games.{Game, GameState, Grid, Round, GrowthCycle, MutationPointsEarned}
+  alias FungusToast.Games.{Game, GameState, Grid, Round, GrowthCycle, PointsEarned}
   alias FungusToast.Game.Status
 
   @starting_mutation_points 5
@@ -146,7 +146,7 @@ defmodule FungusToast.Games do
 
     mutation_points_map = Enum.reduce(growth_summary.growth_cycles, player_to_mutation_points_map, fn growth_cycle, acc ->
       mutation_points_earned_map = Enum.map(growth_cycle.mutation_points_earned, fn mutuation_points_earned ->
-        {mutuation_points_earned.player_id, mutuation_points_earned.mutation_points}
+        {mutuation_points_earned.player_id, mutuation_points_earned.points}
       end)
       |> Enum.into(%{})
 
@@ -258,7 +258,7 @@ defmodule FungusToast.Games do
   end
 
   def get_starting_mutation_points(players) do
-    Enum.map(players, fn player -> %MutationPointsEarned{player_id: player.id, mutation_points: @starting_mutation_points} end)
+    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: @starting_mutation_points} end)
   end
 
   def create_game_for_user(game_changeset, user_name) when is_binary(user_name) do

--- a/lib/fungus_toast/games/games.ex
+++ b/lib/fungus_toast/games/games.ex
@@ -448,15 +448,15 @@ defmodule FungusToast.Games do
   def spend_human_player_mutation_points(player_id, game_id, passive_skill_upgrades, active_skill_changes \\ %{}) do
     #TODO check if the game is started and throw a 400 bad request if not
     player = Players.get_player!(player_id)
-    spent_points = PlayerSkills.sum_skill_upgrades(passive_skill_upgrades)
-    if(spent_points > player.mutation_points) do
+    spent_mutation_points = PlayerSkills.sum_skill_upgrades(passive_skill_upgrades)
+    if(spent_mutation_points > player.mutation_points) do
       {:error_illegal_number_of_points_spent}
     else
       if(ActiveCellChanges.update_active_cell_changes(player, game_id, active_skill_changes)) do
-        total_spent_points = player.spent_mutation_points + spent_points
+        total_spent_points = player.spent_mutation_points + spent_mutation_points
 
         player_changes = PlayerSkills.update_player_skills_and_get_player_changes(player, passive_skill_upgrades)
-        |> Map.put(:mutation_points, player.mutation_points - spent_points)
+        |> Map.put(:mutation_points, player.mutation_points - spent_mutation_points)
         |> Map.put(:spent_mutation_points, total_spent_points)
 
         updated_player = Players.update_player(player, player_changes)

--- a/lib/fungus_toast/games/games.ex
+++ b/lib/fungus_toast/games/games.ex
@@ -8,7 +8,7 @@ defmodule FungusToast.Games do
   alias FungusToast.{Repo, Accounts, Players, PlayerSkills, Rounds, ActiveCellChanges}
   alias FungusToast.Accounts.User
 
-  alias FungusToast.Games.{Game, GameState, Grid, Round, GrowthCycle, PointsEarned}
+  alias FungusToast.Games.{Game, GameState, Grid, Round, GrowthCycle, PointsEarned, Player}
   alias FungusToast.Game.Status
 
   @starting_end_of_game_count_down 5
@@ -153,7 +153,7 @@ defmodule FungusToast.Games do
       Map.merge(acc, mutation_points_earned_map, fn _k, v1, v2 -> v1 + v2 end)
     end)
 
-    action_points_map = Enum.map(players, fn player -> {player.id, PointsEarned.starting_action_points()} end)
+    action_points_map = Enum.map(players, fn player -> {player.id, player.action_points + PointsEarned.default_action_points_per_round()} end)
     |> Enum.into(%{})
 
     player_ids = Enum.map(players, fn player -> player.id end)
@@ -263,11 +263,11 @@ defmodule FungusToast.Games do
   end
 
   def get_starting_mutation_points(players) do
-    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: PointsEarned.starting_mutation_points()} end)
+    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: Player.default_starting_mutation_points()} end)
   end
 
   def get_starting_action_points(players) do
-    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: PointsEarned.starting_action_points()} end)
+    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: PointsEarned.default_action_points_per_round()} end)
   end
 
   def create_game_for_user(game_changeset, user_name) when is_binary(user_name) do

--- a/lib/fungus_toast/games/games.ex
+++ b/lib/fungus_toast/games/games.ex
@@ -11,8 +11,6 @@ defmodule FungusToast.Games do
   alias FungusToast.Games.{Game, GameState, Grid, Round, GrowthCycle, PointsEarned}
   alias FungusToast.Game.Status
 
-  @starting_mutation_points 5
-  @starting_action_points 1
   @starting_end_of_game_count_down 5
   def starting_end_of_game_count_down, do: @starting_end_of_game_count_down
 
@@ -155,7 +153,7 @@ defmodule FungusToast.Games do
       Map.merge(acc, mutation_points_earned_map, fn _k, v1, v2 -> v1 + v2 end)
     end)
 
-    action_points_map = Enum.map(players, fn player -> {player.id, @starting_action_points} end)
+    action_points_map = Enum.map(players, fn player -> {player.id, PointsEarned.starting_action_points()} end)
     |> Enum.into(%{})
 
     player_ids = Enum.map(players, fn player -> player.id end)
@@ -265,11 +263,11 @@ defmodule FungusToast.Games do
   end
 
   def get_starting_mutation_points(players) do
-    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: @starting_mutation_points} end)
+    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: PointsEarned.starting_mutation_points()} end)
   end
 
   def get_starting_action_points(players) do
-    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: @starting_action_points} end)
+    Enum.map(players, fn player -> %PointsEarned{player_id: player.id, points: PointsEarned.starting_action_points()} end)
   end
 
   def create_game_for_user(game_changeset, user_name) when is_binary(user_name) do

--- a/lib/fungus_toast/games/games.ex
+++ b/lib/fungus_toast/games/games.ex
@@ -452,7 +452,7 @@ defmodule FungusToast.Games do
     if(spent_points > player.mutation_points) do
       {:error_illegal_number_of_points_spent}
     else
-      if(ActiveCellChanges.update_active_cell_changes(player_id, game_id, active_skill_changes)) do
+      if(ActiveCellChanges.update_active_cell_changes(player, game_id, active_skill_changes)) do
         total_spent_points = player.spent_mutation_points + spent_points
 
         player_changes = PlayerSkills.update_player_skills_and_get_player_changes(player, passive_skill_upgrades)

--- a/lib/fungus_toast/games/grid.ex
+++ b/lib/fungus_toast/games/grid.ex
@@ -1,6 +1,6 @@
 defmodule FungusToast.Games.Grid do
   alias FungusToast.Games.{CellGrower, GridCell, GrowthCycle, MutationPointsEarned, PlayerStatsChange}
-  alias FungusToast.{Skills, Random}
+  alias FungusToast.{ActiveSkills, Random}
 
   @spec create_starting_grid(integer(), [integer()]) :: any()
   def create_starting_grid(grid_size, player_ids) do
@@ -168,7 +168,7 @@ defmodule FungusToast.Games.Grid do
       active_cell_changes
     end
     active_toast_changes = Enum.reduce(active_cell_changes, [], fn active_cell_change, acc ->
-      grid_cells = if(active_cell_change.skill_id == Skills.skill_id_eye_dropper()) do
+      grid_cells = if(active_cell_change.active_skill_id == ActiveSkills.skill_id_eye_dropper()) do
         Enum.map(active_cell_change.cell_indexes, fn index ->
           %GridCell{index: index, moist: true}
         end)

--- a/lib/fungus_toast/games/grid.ex
+++ b/lib/fungus_toast/games/grid.ex
@@ -168,13 +168,13 @@ defmodule FungusToast.Games.Grid do
       active_cell_changes
     end
     active_toast_changes = Enum.reduce(active_cell_changes, [], fn active_cell_change, acc ->
-      grid_cells = if(active_cell_change.skill_id == Skills.skill_id_hydrophilia()) do
+      grid_cells = if(active_cell_change.skill_id == Skills.skill_id_eye_dropper()) do
         Enum.map(active_cell_change.cell_indexes, fn index ->
           %GridCell{index: index, moist: true}
         end)
       else
         if(active_cell_change.cell_indexes != nil and length(active_cell_change.cell_indexes) > 0) do
-          raise "Hydrophilia is currently the only skill that supports active cell changes, but you attemped to place some for skill with id #{active_cell_change.skill_id}!"
+          raise "Eye Dropper is currently the only skill that supports active cell changes, but you attemped to place some for skill with id #{active_cell_change.skill_id}!"
         else
           []
         end

--- a/lib/fungus_toast/games/grid.ex
+++ b/lib/fungus_toast/games/grid.ex
@@ -1,5 +1,5 @@
 defmodule FungusToast.Games.Grid do
-  alias FungusToast.Games.{CellGrower, GridCell, GrowthCycle, MutationPointsEarned, PlayerStatsChange}
+  alias FungusToast.Games.{CellGrower, GridCell, GrowthCycle, PointsEarned, PlayerStatsChange}
   alias FungusToast.{ActiveSkills, Random}
 
   @spec create_starting_grid(integer(), [integer()]) :: any()
@@ -64,8 +64,8 @@ defmodule FungusToast.Games.Grid do
       %FungusToast.Games.GrowthCycle{
         generation_number: 1,
         mutation_points_earned: [
-          %FungusToast.Games.MutationPointsEarned{
-            mutation_points: 1,
+          %FungusToast.Games.PointsEarned{
+            points: 1,
             player_id: 1
           }
         ],
@@ -83,8 +83,8 @@ defmodule FungusToast.Games.Grid do
       %FungusToast.Games.GrowthCycle{
         generation_number: 2,
         mutation_points_earned: [
-          %FungusToast.Games.MutationPointsEarned{
-            mutation_points: 1,
+          %FungusToast.Games.PointsEarned{
+            points: 1,
             player_id: 1
           }
         ],
@@ -102,8 +102,8 @@ defmodule FungusToast.Games.Grid do
       %FungusToast.Games.GrowthCycle{
         generation_number: 3,
         mutation_points_earned: [
-          %FungusToast.Games.MutationPointsEarned{
-            mutation_points: 1,
+          %FungusToast.Games.PointsEarned{
+            points: 1,
             player_id: 1
           }
         ],
@@ -121,8 +121,8 @@ defmodule FungusToast.Games.Grid do
       %FungusToast.Games.GrowthCycle{
         generation_number: 4,
         mutation_points_earned: [
-          %FungusToast.Games.MutationPointsEarned{
-            mutation_points: 1,
+          %FungusToast.Games.PointsEarned{
+            points: 1,
             player_id: 1
           }
         ],
@@ -140,8 +140,8 @@ defmodule FungusToast.Games.Grid do
       %FungusToast.Games.GrowthCycle{
         generation_number: 5,
         mutation_points_earned: [
-          %FungusToast.Games.MutationPointsEarned{
-            mutation_points: 1,
+          %FungusToast.Games.PointsEarned{
+            points: 1,
             player_id: 1
           }
         ],
@@ -208,7 +208,7 @@ defmodule FungusToast.Games.Grid do
 
     mutation_points = Enum.map(player_id_to_player_map,
       fn{player_id, player}
-        -> %MutationPointsEarned{player_id: player_id, mutation_points: calculate_mutation_points(player)}
+        -> %PointsEarned{player_id: player_id, points: calculate_mutation_points(player)}
       end)
 
     toast_changes_grid_cell_list = Enum.map(toast_changes, fn {_k, grid_cell} -> grid_cell end)

--- a/lib/fungus_toast/games/grid.ex
+++ b/lib/fungus_toast/games/grid.ex
@@ -56,102 +56,105 @@ defmodule FungusToast.Games.Grid do
   %{
     growth_cycles: [
       %FungusToast.Games.GrowthCycle{
+        action_points_earned: [
+          %FungusToast.Games.PointsEarned{player_id: 1, points: 1}
+        ],
         generation_number: 0,
         mutation_points_earned: [],
         player_stats_changes: [],
         toast_changes: []
       },
       %FungusToast.Games.GrowthCycle{
+        action_points_earned: [],
         generation_number: 1,
         mutation_points_earned: [
-          %FungusToast.Games.PointsEarned{
-            points: 1,
-            player_id: 1
-          }
+          %FungusToast.Games.PointsEarned{player_id: 1, points: 1}
         ],
         player_stats_changes: [
           %FungusToast.Games.PlayerStatsChange{
             fungicidal_kills: 0,
             grown_cells: 0,
+            lost_dead_cells: 0,
             perished_cells: 0,
             player_id: 1,
-            regenerated_cells: 0
+            regenerated_cells: 0,
+            stolen_dead_cells: 0
           }
         ],
         toast_changes: []
       },
       %FungusToast.Games.GrowthCycle{
+        action_points_earned: [],
         generation_number: 2,
         mutation_points_earned: [
-          %FungusToast.Games.PointsEarned{
-            points: 1,
-            player_id: 1
-          }
+          %FungusToast.Games.PointsEarned{player_id: 1, points: 1}
         ],
         player_stats_changes: [
           %FungusToast.Games.PlayerStatsChange{
             fungicidal_kills: 0,
             grown_cells: 0,
+            lost_dead_cells: 0,
             perished_cells: 0,
             player_id: 1,
-            regenerated_cells: 0
+            regenerated_cells: 0,
+            stolen_dead_cells: 0
           }
         ],
         toast_changes: []
       },
       %FungusToast.Games.GrowthCycle{
+        action_points_earned: [],
         generation_number: 3,
         mutation_points_earned: [
-          %FungusToast.Games.PointsEarned{
-            points: 1,
-            player_id: 1
-          }
+          %FungusToast.Games.PointsEarned{player_id: 1, points: 1}
         ],
         player_stats_changes: [
           %FungusToast.Games.PlayerStatsChange{
             fungicidal_kills: 0,
             grown_cells: 0,
+            lost_dead_cells: 0,
             perished_cells: 0,
             player_id: 1,
-            regenerated_cells: 0
+            regenerated_cells: 0,
+            stolen_dead_cells: 0
           }
         ],
         toast_changes: []
       },
       %FungusToast.Games.GrowthCycle{
+        action_points_earned: [],
         generation_number: 4,
         mutation_points_earned: [
-          %FungusToast.Games.PointsEarned{
-            points: 1,
-            player_id: 1
-          }
+          %FungusToast.Games.PointsEarned{player_id: 1, points: 1}
         ],
         player_stats_changes: [
           %FungusToast.Games.PlayerStatsChange{
             fungicidal_kills: 0,
             grown_cells: 0,
+            lost_dead_cells: 0,
             perished_cells: 0,
             player_id: 1,
-            regenerated_cells: 0
+            regenerated_cells: 0,
+            stolen_dead_cells: 0
           }
         ],
         toast_changes: []
       },
       %FungusToast.Games.GrowthCycle{
+        action_points_earned: [],
         generation_number: 5,
         mutation_points_earned: [
-          %FungusToast.Games.PointsEarned{
-            points: 1,
-            player_id: 1
-          }
+          %FungusToast.Games.PointsEarned{player_id: 1, points: 1}
         ],
         player_stats_changes: [
           %FungusToast.Games.PlayerStatsChange{
             fungicidal_kills: 0,
             grown_cells: 0,
+            lost_dead_cells: 0,
             perished_cells: 0,
             player_id: 1,
-            regenerated_cells: 0
+            regenerated_cells: 0,
+            stolen_dead_cells: 0
           }
         ],
         toast_changes: []
@@ -159,7 +162,6 @@ defmodule FungusToast.Games.Grid do
     ],
     new_game_state: []
   }
-
   """
   def generate_growth_summary(starting_grid_map, active_cell_changes, grid_size, player_id_to_player_map, generation_number \\ 1) do
     active_cell_changes = if(active_cell_changes == nil) do
@@ -185,10 +187,16 @@ defmodule FungusToast.Games.Grid do
 
     pre_generation_number = generation_number - 1
 
+    #each player gets one action point each round
+    action_points = Enum.map(player_id_to_player_map, fn{player_id, _player}
+      -> %PointsEarned{player_id: player_id, points: PointsEarned.starting_action_points()}
+    end)
+
     active_cell_changes_growth_cycle = %GrowthCycle{
       generation_number: pre_generation_number,
       toast_changes: active_toast_changes,
-      mutation_points_earned: []
+      mutation_points_earned: [],
+      action_points_earned: action_points
     }
 
     active_toast_changes_map = Enum.into(active_toast_changes, %{}, fn grid_cell -> {grid_cell.index, grid_cell} end)

--- a/lib/fungus_toast/games/grid.ex
+++ b/lib/fungus_toast/games/grid.ex
@@ -226,7 +226,8 @@ defmodule FungusToast.Games.Grid do
       generation_number: generation_number,
       toast_changes: toast_changes_grid_cell_list,
       player_stats_changes: player_stats_map,
-      mutation_points_earned: mutation_points
+      mutation_points_earned: mutation_points,
+      action_points_earned: []
     }
 
     #merge the maps together. The changes from the growth cycle replace what's in the grid if there are conflicts.

--- a/lib/fungus_toast/games/grid.ex
+++ b/lib/fungus_toast/games/grid.ex
@@ -189,7 +189,7 @@ defmodule FungusToast.Games.Grid do
 
     #each player gets one action point each round
     action_points = Enum.map(player_id_to_player_map, fn{player_id, _player}
-      -> %PointsEarned{player_id: player_id, points: PointsEarned.starting_action_points()}
+      -> %PointsEarned{player_id: player_id, points: PointsEarned.default_action_points_per_round()}
     end)
 
     active_cell_changes_growth_cycle = %GrowthCycle{

--- a/lib/fungus_toast/games/growth_cycle.ex
+++ b/lib/fungus_toast/games/growth_cycle.ex
@@ -14,7 +14,7 @@ defmodule FungusToast.Games.GrowthCycle do
     field :generation_number, :integer, default: 0
     embeds_many :toast_changes, FungusToast.Games.GridCell, on_replace: :delete
     embeds_many :player_stats_changes, FungusToast.Games.PlayerStatsChange, on_replace: :delete
-    embeds_many :mutation_points_earned, FungusToast.Games.MutationPointsEarned, on_replace: :delete
+    embeds_many :mutation_points_earned, FungusToast.Games.PointsEarned, on_replace: :delete
   end
 
   def changeset(growth_cycle, %__MODULE__{} = attrs) do

--- a/lib/fungus_toast/games/growth_cycle.ex
+++ b/lib/fungus_toast/games/growth_cycle.ex
@@ -5,7 +5,8 @@ defmodule FungusToast.Games.GrowthCycle do
   @attrs [
     :generation_number,
     :toast_changes,
-    :mutation_points_earned
+    :mutation_points_earned,
+    :action_points_earned
   ]
 
   @derive Jason.Encoder
@@ -15,6 +16,7 @@ defmodule FungusToast.Games.GrowthCycle do
     embeds_many :toast_changes, FungusToast.Games.GridCell, on_replace: :delete
     embeds_many :player_stats_changes, FungusToast.Games.PlayerStatsChange, on_replace: :delete
     embeds_many :mutation_points_earned, FungusToast.Games.PointsEarned, on_replace: :delete
+    embeds_many :action_points_earned, FungusToast.Games.PointsEarned, on_replace: :delete
   end
 
   def changeset(growth_cycle, %__MODULE__{} = attrs) do
@@ -26,6 +28,7 @@ defmodule FungusToast.Games.GrowthCycle do
     |> change(attrs)
     |> cast_embed(:toast_changes)
     |> cast_embed(:mutation_points_earned)
+    |> cast_embed(:action_points_earned)
     #TODO validate_required isn't working here and I can't figure out why
     |> validate_required(@attrs)
   end

--- a/lib/fungus_toast/games/helpers/active_cell_changes.ex
+++ b/lib/fungus_toast/games/helpers/active_cell_changes.ex
@@ -9,33 +9,45 @@ defmodule FungusToast.ActiveCellChanges do
 
   #TODO should we add number of active skill changes to player? Should these accumulate or must you spend one per round?
 
-  defp active_cell_changes_are_valid(upgrade_attrs) do
-    Enum.reduce(upgrade_attrs, true, fn {active_skill_id, map}, acc ->
-      total_active_changes_for_skill = length(Map.get(map, "active_cell_changes"))
-      points_spent = Map.get(map, "points_spent")
-      max_allowed_active_changes = ActiveSkills.get_allowed_number_of_active_changes(active_skill_id) * points_spent
-      acc and total_active_changes_for_skill <= max_allowed_active_changes
+  defp active_cell_changes_are_valid(player, upgrade_attrs) do
+    total_action_points_spent = Enum.reduce(upgrade_attrs, 0, fn {_active_skill_id, map}, acc ->
+      Map.get(map, "points_spent") + acc
     end)
-  end
-
-
-  @spec update_active_cell_changes(any, any, any) :: boolean
-  def update_active_cell_changes(player_id, game_id, upgrade_attrs) do
-    if(active_cell_changes_are_valid(upgrade_attrs)) do
-      active_cell_changes = Enum.map(upgrade_attrs, fn {active_skill_id, map} ->
-        %ActiveCellChange{active_skill_id: active_skill_id, player_id: player_id, cell_indexes: Map.get(map, "active_cell_changes")}
+    if(total_action_points_spent > player.action_points) do
+      {:error, :not_enough_action_points}
+    else
+      legal_number_of_active_cell_changes = Enum.reduce(upgrade_attrs, true, fn {active_skill_id, map}, acc ->
+        total_active_changes_for_skill = length(Map.get(map, "active_cell_changes"))
+        points_spent = Map.get(map, "points_spent")
+        max_allowed_active_changes = ActiveSkills.get_allowed_number_of_active_changes(active_skill_id) * points_spent
+        acc and total_active_changes_for_skill <= max_allowed_active_changes
       end)
 
-      if(length(active_cell_changes) > 0) do
-        latest_round = Rounds.get_latest_round_for_game(game_id)
-
-        new_active_cell_changes = latest_round.active_cell_changes ++ active_cell_changes
-        Rounds.update_round(latest_round, %{active_cell_changes: new_active_cell_changes})
+      if(legal_number_of_active_cell_changes) do
+        {:ok, total_action_points_spent}
+      else
+        {:error, :too_many_active_cell_changes}
       end
-      true
+    end
+  end
 
-    else
-      false
+  @spec update_active_cell_changes(any, any, any) :: boolean
+  def update_active_cell_changes(player, game_id, upgrade_attrs) do
+    case active_cell_changes_are_valid(player, upgrade_attrs) do
+      {:ok, points_spent} ->
+        active_cell_changes = Enum.map(upgrade_attrs, fn {active_skill_id, map} ->
+          %ActiveCellChange{active_skill_id: active_skill_id, player_id: player.id, cell_indexes: Map.get(map, "active_cell_changes")}
+        end)
+
+        if(length(active_cell_changes) > 0) do
+          #TODO update the player's action points
+          latest_round = Rounds.get_latest_round_for_game(game_id)
+
+          new_active_cell_changes = latest_round.active_cell_changes ++ active_cell_changes
+          Rounds.update_round(latest_round, %{active_cell_changes: new_active_cell_changes})
+        end
+        true
+      {:error, _} -> false
     end
   end
 end

--- a/lib/fungus_toast/games/helpers/active_cell_changes.ex
+++ b/lib/fungus_toast/games/helpers/active_cell_changes.ex
@@ -1,5 +1,5 @@
 defmodule FungusToast.ActiveCellChanges do
-  alias FungusToast.{Skills, Rounds}
+  alias FungusToast.{ActiveSkills, Rounds}
   alias FungusToast.Games.ActiveCellChange
 
   @moduledoc """
@@ -8,10 +8,10 @@ defmodule FungusToast.ActiveCellChanges do
   """
 
   defp active_cell_changes_are_valid(upgrade_attrs) do
-    Enum.reduce(upgrade_attrs, true, fn {skill_id, map}, acc ->
+    Enum.reduce(upgrade_attrs, true, fn {active_skill_id, map}, acc ->
       total_active_changes_for_skill = length(Map.get(map, "active_cell_changes"))
       points_spent = Map.get(map, "points_spent")
-      max_allowed_active_changes = Skills.get_allowed_number_of_active_changes(skill_id) * points_spent
+      max_allowed_active_changes = ActiveSkills.get_allowed_number_of_active_changes(active_skill_id) * points_spent
       acc and total_active_changes_for_skill <= max_allowed_active_changes
     end)
   end
@@ -19,8 +19,8 @@ defmodule FungusToast.ActiveCellChanges do
 
   def update_active_cell_changes(player_id, game_id, upgrade_attrs) do
     if(active_cell_changes_are_valid(upgrade_attrs)) do
-      active_cell_changes = Enum.map(upgrade_attrs, fn {skill_id, map} ->
-        %ActiveCellChange{skill_id: skill_id, player_id: player_id, cell_indexes: Map.get(map, "active_cell_changes")}
+      active_cell_changes = Enum.map(upgrade_attrs, fn {active_skill_id, map} ->
+        %ActiveCellChange{active_skill_id: active_skill_id, player_id: player_id, cell_indexes: Map.get(map, "active_cell_changes")}
       end)
 
       if(length(active_cell_changes) > 0) do

--- a/lib/fungus_toast/games/helpers/active_cell_changes.ex
+++ b/lib/fungus_toast/games/helpers/active_cell_changes.ex
@@ -1,6 +1,6 @@
 defmodule FungusToast.ActiveCellChanges do
-  alias FungusToast.{ActiveSkills, Rounds}
-  alias FungusToast.Games.ActiveCellChange
+  alias FungusToast.{ActiveSkills, Rounds, Players}
+  alias FungusToast.Games.{ActiveCellChange}
 
   @moduledoc """
   Provides functions for dealing with active cell changes. Active cell changes are player-generated manipulations of the toast
@@ -13,13 +13,14 @@ defmodule FungusToast.ActiveCellChanges do
     total_action_points_spent = Enum.reduce(upgrade_attrs, 0, fn {_active_skill_id, map}, acc ->
       Map.get(map, "points_spent") + acc
     end)
+
     if(total_action_points_spent > player.action_points) do
       {:error, :not_enough_action_points}
     else
       legal_number_of_active_cell_changes = Enum.reduce(upgrade_attrs, true, fn {active_skill_id, map}, acc ->
         total_active_changes_for_skill = length(Map.get(map, "active_cell_changes"))
-        points_spent = Map.get(map, "points_spent")
-        max_allowed_active_changes = ActiveSkills.get_allowed_number_of_active_changes(active_skill_id) * points_spent
+        action_points_spent = Map.get(map, "points_spent")
+        max_allowed_active_changes = ActiveSkills.get_allowed_number_of_active_changes(active_skill_id) * action_points_spent
         acc and total_active_changes_for_skill <= max_allowed_active_changes
       end)
 
@@ -34,13 +35,14 @@ defmodule FungusToast.ActiveCellChanges do
   @spec update_active_cell_changes(any, any, any) :: boolean
   def update_active_cell_changes(player, game_id, upgrade_attrs) do
     case active_cell_changes_are_valid(player, upgrade_attrs) do
-      {:ok, points_spent} ->
+      {:ok, action_points_spent} ->
         active_cell_changes = Enum.map(upgrade_attrs, fn {active_skill_id, map} ->
           %ActiveCellChange{active_skill_id: active_skill_id, player_id: player.id, cell_indexes: Map.get(map, "active_cell_changes")}
         end)
 
         if(length(active_cell_changes) > 0) do
           #TODO update the player's action points
+          Players.update_player(player, %{action_points: player.action_points - action_points_spent})
           latest_round = Rounds.get_latest_round_for_game(game_id)
 
           new_active_cell_changes = latest_round.active_cell_changes ++ active_cell_changes

--- a/lib/fungus_toast/games/helpers/active_cell_changes.ex
+++ b/lib/fungus_toast/games/helpers/active_cell_changes.ex
@@ -7,6 +7,8 @@ defmodule FungusToast.ActiveCellChanges do
   resulting from certain skills. These changes are applied to the toast at the start of the round, before growth cycles.
   """
 
+  #TODO should we add number of active skill changes to player? Should these accumulate or must you spend one per round?
+
   defp active_cell_changes_are_valid(upgrade_attrs) do
     Enum.reduce(upgrade_attrs, true, fn {active_skill_id, map}, acc ->
       total_active_changes_for_skill = length(Map.get(map, "active_cell_changes"))
@@ -17,6 +19,7 @@ defmodule FungusToast.ActiveCellChanges do
   end
 
 
+  @spec update_active_cell_changes(any, any, any) :: boolean
   def update_active_cell_changes(player_id, game_id, upgrade_attrs) do
     if(active_cell_changes_are_valid(upgrade_attrs)) do
       active_cell_changes = Enum.map(upgrade_attrs, fn {active_skill_id, map} ->

--- a/lib/fungus_toast/games/helpers/active_skills.ex
+++ b/lib/fungus_toast/games/helpers/active_skills.ex
@@ -1,0 +1,145 @@
+defmodule FungusToast.ActiveSkills do
+  import Ecto.Query, warn: false
+  alias FungusToast.Repo
+
+  alias FungusToast.Games.ActiveSkill
+
+  def skill_id_eye_dropper, do: 1
+  def number_of_toast_changes_for_eye_dropper, do: 3
+
+  #TODO this should come from the database instead of being hard-coded here
+  defp skill_to_number_of_active_changes_map, do: %{
+    skill_id_eye_dropper() => number_of_toast_changes_for_eye_dropper()
+  }
+
+  def get_allowed_number_of_active_changes(active_skill_id) when is_integer(active_skill_id) do
+    Map.get(skill_to_number_of_active_changes_map(), active_skill_id)
+  end
+
+  def get_allowed_number_of_active_changes(active_skill_id) when is_binary(active_skill_id) do
+    Map.get(skill_to_number_of_active_changes_map(), String.to_integer(active_skill_id))
+  end
+
+  @doc """
+  Returns the list of skills.
+
+  ## Examples
+
+      iex> list_skills()
+      [%ActiveSkill{}, ...]
+
+  """
+  def list_skills do
+    Repo.all(ActiveSkill)
+  end
+
+  @doc """
+  Gets a single skill.
+
+  Raises `Ecto.NoResultsError` if the Skill does not exist.
+
+  ## Examples
+
+      iex> get_skill_by_name("Eye Dropper")
+      %ActiveSkill{}
+
+      iex> get_skill_by_name("invalid")
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_active_skill_by_name(name) do
+    from(s in ActiveSkill, where: s.name == ^name) |> Repo.one
+  end
+
+  @doc """
+  Gets a single active skill (using an integer skill id)
+
+  Raises `Ecto.NoResultsError` if the Skill does not exist.
+
+  ## Examples
+
+      iex> get_active_skill!(123)
+      %ActiveSkill{}
+
+      iex> get_active_skill!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_active_skill!(id) when is_integer(id) do
+    Repo.get!(ActiveSkill, id)
+  end
+
+  @doc """
+  Gets a single active skill (using a string skill id)
+
+  Raises `Ecto.NoResultsError` if the Skill does not exist.
+  """
+  def get_active_skill!(id) when is_binary(id) do
+    Repo.get!(ActiveSkill, String.to_integer(id))
+  end
+
+  @doc """
+  Creates an active skill.
+
+  ## Examples
+
+      iex> create_active_skill(%{field: value})
+      {:ok, %ActiveSkill{}}
+
+      iex> create_active_skill(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_active_skill(attrs \\ %{}) do
+    %ActiveSkill{}
+    |> ActiveSkill.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates an active skill.
+
+  ## Examples
+
+      iex> update_active_skill(active_skill, %{field: new_value})
+      {:ok, %ActiveSkill{}}
+
+      iex> update_active_skill(active_skill, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_active_skill(%ActiveSkill{} = active_skill, attrs) do
+    active_skill
+    |> ActiveSkill.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes an active skill.
+
+  ## Examples
+
+      iex> delete_active_skill(active_skill)
+      {:ok, %ActiveSkill{}}
+
+      iex> delete_active_skill(active_skill)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_active_skill(%ActiveSkill{} = active_skill) do
+    Repo.delete(active_skill)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking skill changes.
+
+  ## Examples
+
+      iex> change_active_skill(active_skill)
+      %Ecto.Changeset{source: %ActiveSkill{}}
+
+  """
+  def change_active_skill(%ActiveSkill{} = active_skill) do
+    ActiveSkill.changeset(active_skill, %{})
+  end
+end

--- a/lib/fungus_toast/games/helpers/ai_strategies.ex
+++ b/lib/fungus_toast/games/helpers/ai_strategies.ex
@@ -37,6 +37,8 @@ defmodule FungusToast.AiStrategies do
   def skill_name_hydrophilia, do: @skill_name_hydrophilia
   @skill_name_spores "Spores"
   def skill_name_spores, do: @skill_name_spores
+  @skill_name_eye_dropper "Eye Dropper"
+  def skill_name_eye_dropper, do: @skill_name_eye_dropper
 
   @skill_name_to_player_attribute_map %{
     @skill_name_anti_apoptosis => [:apoptosis_chance],
@@ -57,7 +59,12 @@ defmodule FungusToast.AiStrategies do
   def skills_that_bottom_out_at_0_percent, do: @skills_that_bottom_out_at_0_percent
 
   def get_player_attributes_for_skill_name(skill_name) do
-    Map.get(@skill_name_to_player_attribute_map, skill_name)
+    attributes = Map.get(@skill_name_to_player_attribute_map, skill_name)
+    if(attributes == nil) do
+      []
+    else
+      attributes
+    end
   end
 
   @candidate_skills_map %{
@@ -125,7 +132,11 @@ defmodule FungusToast.AiStrategies do
 
   @spec maxed_out_skill?(String.t(), %Player{}) :: boolean()
   def maxed_out_skill?(skill_name, player) do
-    attribute_to_check = hd(get_player_attributes_for_skill_name(skill_name))
+    attributes = get_player_attributes_for_skill_name(skill_name)
+    if(attributes == []) do
+      false
+    else
+      attribute_to_check = hd(attributes)
     percentage_chance = Map.get(player, attribute_to_check)
     return_value = if(Enum.member?(@skills_that_bottom_out_at_0_percent, skill_name)) do
       if(percentage_chance <= 0) do
@@ -142,5 +153,6 @@ defmodule FungusToast.AiStrategies do
     end
 
     return_value
+    end
   end
 end

--- a/lib/fungus_toast/games/helpers/player_skills.ex
+++ b/lib/fungus_toast/games/helpers/player_skills.ex
@@ -112,10 +112,8 @@ defmodule FungusToast.PlayerSkills do
     update_player_skills(player, skill_upgrades)
   end
 
-  def update_player_skills_and_get_player_changes(%Player{} = player, upgrade_attrs) do
-    Enum.reduce(upgrade_attrs, %{}, fn {skill_id, map}, acc ->
-      points_spent = Map.get(map, "points_spent")
-
+  def update_player_skills_and_get_player_changes(%Player{} = player, passive_skill_upgrades) do
+    Enum.reduce(passive_skill_upgrades, %{}, fn {skill_id, points_spent}, acc ->
       skill = Skills.get_skill!(skill_id)
 
       player_skill = get_player_skill(player.id, skill_id)
@@ -176,7 +174,7 @@ defmodule FungusToast.PlayerSkills do
   """
   def sum_skill_upgrades(skill_upgrades) do
     skill_upgrades
-    |> Enum.reduce(0, fn {_, map}, acc -> acc + Map.get(map, "points_spent") end)
+    |> Enum.reduce(0, fn {_skill_id, points_spent}, acc -> acc + points_spent end)
   end
 
   @doc """

--- a/lib/fungus_toast/games/helpers/skills.ex
+++ b/lib/fungus_toast/games/helpers/skills.ex
@@ -11,6 +11,7 @@ defmodule FungusToast.Skills do
   def skill_id_mycotoxicity, do: 5
   def skill_id_hydrophilia, do: 6
   def skill_id_spores, do: 7
+  def skill_id_eye_dropper, do: 8
 
   defp skill_to_number_of_active_changes_map, do: %{
     skill_id_hypermutation() => 0,
@@ -18,8 +19,9 @@ defmodule FungusToast.Skills do
     skill_id_anti_apoptosis() => 0,
     skill_id_regeneration() => 0,
     skill_id_mycotoxicity() => 0,
-    skill_id_hydrophilia() => 3,
-    skill_id_spores() => 0
+    skill_id_hydrophilia() => 0,
+    skill_id_spores() => 0,
+    skill_id_eye_dropper() => 5
   }
 
   def get_allowed_number_of_active_changes(skill_id) when is_integer(skill_id) do

--- a/lib/fungus_toast/games/helpers/skills.ex
+++ b/lib/fungus_toast/games/helpers/skills.ex
@@ -11,8 +11,8 @@ defmodule FungusToast.Skills do
   def skill_id_mycotoxicity, do: 5
   def skill_id_hydrophilia, do: 6
   def skill_id_spores, do: 7
-  def skill_id_eye_dropper, do: 8
 
+  #TODO this should come from the database instead of being hard-coded here
   defp skill_to_number_of_active_changes_map, do: %{
     skill_id_hypermutation() => 0,
     skill_id_budding() => 0,
@@ -20,8 +20,7 @@ defmodule FungusToast.Skills do
     skill_id_regeneration() => 0,
     skill_id_mycotoxicity() => 0,
     skill_id_hydrophilia() => 0,
-    skill_id_spores() => 0,
-    skill_id_eye_dropper() => 5
+    skill_id_spores() => 0
   }
 
   def get_allowed_number_of_active_changes(skill_id) when is_integer(skill_id) do

--- a/lib/fungus_toast/games/helpers/skills_seeds.ex
+++ b/lib/fungus_toast/games/helpers/skills_seeds.ex
@@ -8,7 +8,8 @@ defmodule FungusToast.Skills.SkillsSeed do
     description: _,
     increase_per_point: _,
     up_is_good: _,
-    number_of_active_cell_changes: _
+    number_of_active_cell_changes: _,
+    active_skill: _
   }) do
     skill = Skills.get_skill_by_name(name)
     if(skill == nil) do
@@ -16,6 +17,8 @@ defmodule FungusToast.Skills.SkillsSeed do
     else
       Skills.update_skill(skill, changes)
     end
+
+    true
   end
 
   def seed_skills do
@@ -26,7 +29,8 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that you will generate a bonus mutation point during each growth cycle.",
       increase_per_point: 2.0,
       up_is_good: true,
-      number_of_active_cell_changes: 0
+      number_of_active_cell_changes: 0,
+      active_skill: false
     })
 
     upsert_skill(%{
@@ -36,7 +40,8 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that your live cells will bud into a corner (top-left, top-right, bottom-left, bottom-right) cell.",
       increase_per_point: 0.4,
       up_is_good: true,
-      number_of_active_cell_changes: 0
+      number_of_active_cell_changes: 0,
+      active_skill: false
     })
 
     upsert_skill(%{
@@ -45,7 +50,8 @@ defmodule FungusToast.Skills.SkillsSeed do
       description: "Decreases the chance that your cells will die at random.",
       increase_per_point: 0.25,
       up_is_good: false,
-      number_of_active_cell_changes: 0
+      number_of_active_cell_changes: 0,
+      active_skill: false
     })
 
     upsert_skill(%{
@@ -55,7 +61,8 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that your live cell will regenerate an adjacent dead cell (from any player).",
       increase_per_point: 0.25,
       up_is_good: true,
-      number_of_active_cell_changes: 0
+      number_of_active_cell_changes: 0,
+      active_skill: false
     })
 
     upsert_skill(%{
@@ -65,17 +72,19 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that your live cell will kill an adjacent living cell of another player.",
       increase_per_point: 0.25,
       up_is_good: true,
-      number_of_active_cell_changes: 0
+      number_of_active_cell_changes: 0,
+      active_skill: false
     })
 
     upsert_skill(%{
       id: Skills.skill_id_hydrophilia,
       name: "Hydrophilia",
       description:
-        "Increases the chance that your live cell growth into an adjacent moist cell. Also grants 3 water droplets to drop on the toast.",
-      increase_per_point: 2.0,
+        "Increases the chance that your live cell growth into an adjacent moist cell.",
+      increase_per_point: 4.0,
       up_is_good: true,
-      number_of_active_cell_changes: 3 #can drop 3 drops of water
+      number_of_active_cell_changes: 0,
+      active_skill: false
     })
 
     upsert_skill(%{
@@ -85,8 +94,22 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that a cell which fails to grow into an adjacent cell will will release spores and grow into a random cell on the grid.",
       increase_per_point: 0.10,
       up_is_good: true,
-      number_of_active_cell_changes: 0
+      number_of_active_cell_changes: 0,
+      active_skill: false
     })
+
+    upsert_skill(%{
+      id: Skills.skill_id_eye_dropper,
+      name: "Eye Dropper",
+      description:
+        "Allows you to place 5 drops of water on the toast to make it moist.",
+      increase_per_point: 0,
+      up_is_good: true,
+      number_of_active_cell_changes: 5,
+      active_skill: true
+    })
+
+    true
   end
 
   def reset_skills_in_database() do

--- a/lib/fungus_toast/games/helpers/skills_seeds.ex
+++ b/lib/fungus_toast/games/helpers/skills_seeds.ex
@@ -1,6 +1,5 @@
 defmodule FungusToast.Skills.SkillsSeed do
-  alias FungusToast.Skills
-  alias FungusToast.Repo
+  alias FungusToast.{Repo, Skills, ActiveSkills}
 
   defp upsert_skill(changes = %{
     id: _,
@@ -8,14 +7,30 @@ defmodule FungusToast.Skills.SkillsSeed do
     description: _,
     increase_per_point: _,
     up_is_good: _,
-    number_of_active_cell_changes: _,
-    active_skill: _
+    minimum_round: _
   }) do
     skill = Skills.get_skill_by_name(name)
     if(skill == nil) do
       Skills.create_skill(changes)
     else
       Skills.update_skill(skill, changes)
+    end
+
+    true
+  end
+
+  defp upsert_active_skill(changes = %{
+    id: _,
+    name: name,
+    description: _,
+    number_of_toast_changes: _,
+    minimum_round: _
+  }) do
+    skill = ActiveSkills.get_active_skill_by_name(name)
+    if(skill == nil) do
+      ActiveSkills.create_active_skill(changes)
+    else
+      ActiveSkills.update_active_skill(skill, changes)
     end
 
     true
@@ -29,8 +44,7 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that you will generate a bonus mutation point during each growth cycle.",
       increase_per_point: 2.0,
       up_is_good: true,
-      number_of_active_cell_changes: 0,
-      active_skill: false
+      minimum_round: 0
     })
 
     upsert_skill(%{
@@ -40,8 +54,7 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that your live cells will bud into a corner (top-left, top-right, bottom-left, bottom-right) cell.",
       increase_per_point: 0.4,
       up_is_good: true,
-      number_of_active_cell_changes: 0,
-      active_skill: false
+      minimum_round: 0
     })
 
     upsert_skill(%{
@@ -50,8 +63,7 @@ defmodule FungusToast.Skills.SkillsSeed do
       description: "Decreases the chance that your cells will die at random.",
       increase_per_point: 0.25,
       up_is_good: false,
-      number_of_active_cell_changes: 0,
-      active_skill: false
+      minimum_round: 0
     })
 
     upsert_skill(%{
@@ -61,8 +73,7 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that your live cell will regenerate an adjacent dead cell (from any player).",
       increase_per_point: 0.25,
       up_is_good: true,
-      number_of_active_cell_changes: 0,
-      active_skill: false
+      minimum_round: 0
     })
 
     upsert_skill(%{
@@ -72,8 +83,7 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that your live cell will kill an adjacent living cell of another player.",
       increase_per_point: 0.25,
       up_is_good: true,
-      number_of_active_cell_changes: 0,
-      active_skill: false
+      minimum_round: 0
     })
 
     upsert_skill(%{
@@ -83,8 +93,7 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that your live cell growth into an adjacent moist cell.",
       increase_per_point: 4.0,
       up_is_good: true,
-      number_of_active_cell_changes: 0,
-      active_skill: false
+      minimum_round: 0
     })
 
     upsert_skill(%{
@@ -94,28 +103,31 @@ defmodule FungusToast.Skills.SkillsSeed do
         "Increases the chance that a cell which fails to grow into an adjacent cell will will release spores and grow into a random cell on the grid.",
       increase_per_point: 0.10,
       up_is_good: true,
-      number_of_active_cell_changes: 0,
-      active_skill: false
-    })
-
-    upsert_skill(%{
-      id: Skills.skill_id_eye_dropper,
-      name: "Eye Dropper",
-      description:
-        "Allows you to place 5 drops of water on the toast to make it moist.",
-      increase_per_point: 0,
-      up_is_good: true,
-      number_of_active_cell_changes: 5,
-      active_skill: true
+      minimum_round: 0
     })
 
     true
   end
 
+  def seed_active_skills do
+    upsert_active_skill(%{
+      id: ActiveSkills.skill_id_eye_dropper,
+      name: "Eye Dropper",
+      description:
+        "Allows you to place 3 drops of water on the toast to make it moist.",
+      number_of_toast_changes: ActiveSkills.number_of_toast_changes_for_eye_dropper,
+      minimum_round: 0
+    })
+  end
+
+
   def reset_skills_in_database() do
     Repo.delete_all(FungusToast.Games.Skill)
+    Repo.delete_all(FungusToast.Games.ActiveSkill)
     #reset the identity so the skill ids can match the desired values again
     Repo.query("ALTER SEQUENCE skills_id_seq RESTART")
+    Repo.query("ALTER SEQUENCE active_skills_id_seq RESTART")
     seed_skills()
+    seed_active_skills()
   end
 end

--- a/lib/fungus_toast/games/player.ex
+++ b/lib/fungus_toast/games/player.ex
@@ -23,6 +23,8 @@ defmodule FungusToast.Games.Player do
 
   @default_starting_mutation_points 5
   def default_starting_mutation_points, do: @default_starting_mutation_points
+  @default_starting_action_points 1
+  def default_starting_action_points, do: @default_starting_action_points
 
   @attrs [
     :name,
@@ -95,7 +97,7 @@ defmodule FungusToast.Games.Player do
     field :ai_type, :string, null: true
 
     field :mutation_points, :integer, default: @default_starting_mutation_points, null: false
-    field :action_points, :integer, default: 0, null: false
+    field :action_points, :integer, default: @default_starting_action_points, null: false
 
     field :top_left_growth_chance, :float, default: 0.0, null: false
     field :top_growth_chance, :float, default: @default_top_right_bottom_left_growth_chance, null: false

--- a/lib/fungus_toast/games/player.ex
+++ b/lib/fungus_toast/games/player.ex
@@ -28,6 +28,7 @@ defmodule FungusToast.Games.Player do
     :name,
     :human,
     :mutation_points,
+    :action_points,
     :top_left_growth_chance,
     :top_growth_chance,
     :top_right_growth_chance,
@@ -59,6 +60,7 @@ defmodule FungusToast.Games.Player do
     :name,
     :human,
     :mutation_points,
+    :action_points,
     :top_left_growth_chance,
     :top_growth_chance,
     :top_right_growth_chance,
@@ -93,6 +95,7 @@ defmodule FungusToast.Games.Player do
     field :ai_type, :string, null: true
 
     field :mutation_points, :integer, default: @default_starting_mutation_points, null: false
+    field :action_points, :integer, default: 0, null: false
 
     field :top_left_growth_chance, :float, default: 0.0, null: false
     field :top_growth_chance, :float, default: @default_top_right_bottom_left_growth_chance, null: false

--- a/lib/fungus_toast/games/points_earned.ex
+++ b/lib/fungus_toast/games/points_earned.ex
@@ -2,6 +2,11 @@ defmodule FungusToast.Games.PointsEarned do
   import Ecto.Changeset
   use Ecto.Schema
 
+  @starting_mutation_points 5
+  def starting_mutation_points, do: @starting_mutation_points
+  @starting_action_points 1
+  def starting_action_points, do: @starting_action_points
+
   @attrs [
     :player_id,
     :points

--- a/lib/fungus_toast/games/points_earned.ex
+++ b/lib/fungus_toast/games/points_earned.ex
@@ -1,17 +1,17 @@
-defmodule FungusToast.Games.MutationPointsEarned do
+defmodule FungusToast.Games.PointsEarned do
   import Ecto.Changeset
   use Ecto.Schema
 
   @attrs [
     :player_id,
-    :mutation_points
+    :points
   ]
 
   @derive Jason.Encoder
   @primary_key false
   embedded_schema do
     field :player_id, :integer, null: false
-    field :mutation_points, :integer, null: false
+    field :points, :integer, null: false
   end
 
   def changeset(grid_cell, attrs) do

--- a/lib/fungus_toast/games/points_earned.ex
+++ b/lib/fungus_toast/games/points_earned.ex
@@ -4,8 +4,8 @@ defmodule FungusToast.Games.PointsEarned do
 
   @starting_mutation_points 5
   def starting_mutation_points, do: @starting_mutation_points
-  @starting_action_points 1
-  def starting_action_points, do: @starting_action_points
+  @default_action_points_per_round 1
+  def default_action_points_per_round, do: @default_action_points_per_round
 
   @attrs [
     :player_id,

--- a/lib/fungus_toast/games/skill.ex
+++ b/lib/fungus_toast/games/skill.ex
@@ -16,6 +16,7 @@ defmodule FungusToast.Games.Skill do
     field :number_of_active_cell_changes, :integer, default: 0
     field :name, :string, size: 64
     field :up_is_good, :boolean
+    field :active_skill, :boolean, default: false
 
     timestamps()
   end
@@ -23,7 +24,7 @@ defmodule FungusToast.Games.Skill do
   @doc false
   def changeset(skill, attrs) do
     skill
-    |> cast(attrs, [:name, :description, :increase_per_point, :number_of_active_cell_changes, :up_is_good])
+    |> cast(attrs, [:name, :description, :increase_per_point, :number_of_active_cell_changes, :up_is_good, :active_skill])
     |> validate_required([:name, :description, :increase_per_point])
     |> validate_length(:name, max: 64)
     |> validate_length(:description, max: 512)

--- a/lib/fungus_toast_web/controllers/active_skill_controller.ex
+++ b/lib/fungus_toast_web/controllers/active_skill_controller.ex
@@ -6,7 +6,7 @@ defmodule FungusToastWeb.ActiveSkillController do
   action_fallback FungusToastWeb.FallbackController
 
   def index(conn, _) do
-    skills = ActiveSkills.list_skills()
-    render(conn, "index.json", skills: skills)
+    active_skills = ActiveSkills.list_skills()
+    render(conn, "index.json", active_skills: active_skills)
   end
 end

--- a/lib/fungus_toast_web/controllers/active_skill_controller.ex
+++ b/lib/fungus_toast_web/controllers/active_skill_controller.ex
@@ -1,0 +1,12 @@
+defmodule FungusToastWeb.ActiveSkillController do
+  use FungusToastWeb, :controller
+
+  alias FungusToast.ActiveSkills
+
+  action_fallback FungusToastWeb.FallbackController
+
+  def index(conn, _) do
+    skills = ActiveSkills.list_skills()
+    render(conn, "index.json", skills: skills)
+  end
+end

--- a/lib/fungus_toast_web/controllers/player_skill_controller.ex
+++ b/lib/fungus_toast_web/controllers/player_skill_controller.ex
@@ -17,16 +17,19 @@ defmodule FungusToastWeb.PlayerSkillController do
   # %{
   #   "game_id" => "48",
   #   "player_id" => "50",
-  #   "upgrades" => %{
-  #     "6" => %{"active_cell_changes" => [1, 2, 3, 4], "points_spent" => 0}
+  #   "skill_upgrades" => %{
+  #     "6" => 1}
+  #   },
+  #   "active_skill_changes" => %{
+  #     "8" => %{"active_cell_changes" => [1, 2, 3, 4], "points_spent" => 1}
   #   }
   # }
   def update(conn, params) do
-
     game_id = Map.get(params, "game_id")
     player_id = Map.get(params, "player_id")
-    upgrades = Map.get(params, "upgrades")
-    result = Games.spend_human_player_mutation_points(player_id, game_id, upgrades)
+    skill_upgrades = Map.get(params, "skill_upgrades")
+    active_skill_changes = Map.get(params, "active_skill_changes")
+    result = Games.spend_human_player_mutation_points(player_id, game_id, skill_upgrades, active_skill_changes)
 
     case result do
       {:ok, next_round_available: next_round_available, updated_player: updated_player} ->

--- a/lib/fungus_toast_web/router.ex
+++ b/lib/fungus_toast_web/router.ex
@@ -43,5 +43,9 @@ defmodule FungusToastWeb.Router do
     resources "/skills", SkillController, only: [:index] do
       get "/skills", SkillController, :index, as: :skills
     end
+
+    resources "/active-skills", ActiveSkillController, only: [:index] do
+      get "/active-skills", ActiveSkillController, :index, as: :skills
+    end
   end
 end

--- a/lib/fungus_toast_web/views/active_skill_view.ex
+++ b/lib/fungus_toast_web/views/active_skill_view.ex
@@ -1,0 +1,23 @@
+defmodule FungusToastWeb.ActiveSkillView do
+  use FungusToastWeb, :view
+  alias FungusToastWeb.ActiveSkillView
+
+  def render("index.json", %{active_skills: active_skills}) do
+    render_many(active_skills, ActiveSkillView, "skill.json")
+  end
+
+  def render("show.json", %{active_skill: active_skill}) do
+    render_one(active_skill, ActiveSkillView, "skill.json")
+  end
+
+  def render("skill.json", %{active_skill: active_skill}), do: skill_json(active_skill)
+
+  def skill_json(active_skill) do
+    %{
+      id: active_skill.id,
+      name: active_skill.name,
+      up_is_good: active_skill.up_is_good,
+      increase_per_point: active_skill.increase_per_point
+    }
+  end
+end

--- a/lib/fungus_toast_web/views/active_skill_view.ex
+++ b/lib/fungus_toast_web/views/active_skill_view.ex
@@ -16,8 +16,9 @@ defmodule FungusToastWeb.ActiveSkillView do
     %{
       id: active_skill.id,
       name: active_skill.name,
-      up_is_good: active_skill.up_is_good,
-      increase_per_point: active_skill.increase_per_point
+      description: active_skill.description,
+      minimum_round: active_skill.minimum_round,
+      number_of_toast_changes: active_skill.number_of_toast_changes
     }
   end
 end

--- a/lib/fungus_toast_web/views/game_view.ex
+++ b/lib/fungus_toast_web/views/game_view.ex
@@ -122,7 +122,7 @@ defmodule FungusToastWeb.GameView do
         |> Enum.into(%{})
 
         mutation_points_earned = Enum.map(growth_cycle.mutation_points_earned, fn mutation_points_earned ->
-          {mutation_points_earned.player_id, mutation_points_earned.mutation_points} end)
+          {mutation_points_earned.player_id, mutation_points_earned.points} end)
         |> Enum.into(%{})
 
         %{toast_changes: toast_changes, player_stats_changes: player_stats_changes, mutation_points_earned: mutation_points_earned}

--- a/lib/fungus_toast_web/views/game_view.ex
+++ b/lib/fungus_toast_web/views/game_view.ex
@@ -125,7 +125,11 @@ defmodule FungusToastWeb.GameView do
           {mutation_points_earned.player_id, mutation_points_earned.points} end)
         |> Enum.into(%{})
 
-        %{toast_changes: toast_changes, player_stats_changes: player_stats_changes, mutation_points_earned: mutation_points_earned}
+        action_points_earned = Enum.map(growth_cycle.action_points_earned, fn action_points_earned ->
+          {action_points_earned.player_id, action_points_earned.points} end)
+        |> Enum.into(%{})
+
+        %{toast_changes: toast_changes, player_stats_changes: player_stats_changes, mutation_points_earned: mutation_points_earned, action_points_earned: action_points_earned}
       end)
     end
   end

--- a/lib/fungus_toast_web/views/game_view.ex
+++ b/lib/fungus_toast_web/views/game_view.ex
@@ -55,6 +55,7 @@ defmodule FungusToastWeb.GameView do
       id: player.id,
       name: player.name,
       mutation_points: player.mutation_points,
+      action_points: player.action_points,
       human: player.human,
       top_left_growth_chance: player.top_left_growth_chance,
       top_growth_chance: player.top_growth_chance,

--- a/lib/fungus_toast_web/views/skill_view.ex
+++ b/lib/fungus_toast_web/views/skill_view.ex
@@ -17,7 +17,8 @@ defmodule FungusToastWeb.SkillView do
       id: skill.id,
       name: skill.name,
       up_is_good: skill.up_is_good,
-      increase_per_point: skill.increase_per_point
+      increase_per_point: skill.increase_per_point,
+      minimum_round: skill.minimum_round
     }
   end
 end

--- a/priv/repo/migrations/20190610003051_add_active_skills.exs
+++ b/priv/repo/migrations/20190610003051_add_active_skills.exs
@@ -1,0 +1,9 @@
+defmodule FungusToast.Repo.Migrations.AddActiveSkills do
+  use Ecto.Migration
+
+  def change do
+    alter table(:skills) do
+      add :active_skill, :boolean, null: false, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20190613165614_split_out_active_skills_table.exs
+++ b/priv/repo/migrations/20190613165614_split_out_active_skills_table.exs
@@ -1,0 +1,13 @@
+defmodule FungusToast.Repo.Migrations.SplitOutActiveSkillsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:active_skills) do
+      add :name, :string
+      add :description, :string
+      add :number_of_toast_changes, :integer
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20190614010719_add_minimum_round_to_skills.exs
+++ b/priv/repo/migrations/20190614010719_add_minimum_round_to_skills.exs
@@ -1,0 +1,15 @@
+defmodule FungusToast.Repo.Migrations.AddMinimumRoundToSkills do
+  use Ecto.Migration
+
+  def change do
+    alter table(:skills) do
+      add :minimum_round, :integer, default: 0, null: false
+      remove :active_skill
+      remove :number_of_active_cell_changes
+    end
+
+    alter table(:active_skills) do
+      add :minimum_round, :integer, default: 0, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20190615012044_add_action_points_to_player.exs
+++ b/priv/repo/migrations/20190615012044_add_action_points_to_player.exs
@@ -1,0 +1,9 @@
+defmodule FungusToast.Repo.Migrations.AddActionPointsToPlayer do
+  use Ecto.Migration
+
+  def change do
+    alter table(:players) do
+      add :action_points, :integer, default: 0, null: false
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -24,5 +24,6 @@ Accounts.create_user(%{user_name: "Human 6"})
 
 #create all of the Skills records
 SkillsSeed.seed_skills()
+SkillsSeed.seed_active_skills()
 #temporary until we get registration and authentication working
 UsersSeed.seed_users()

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,7 +9,7 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
-alias FungusToast.{Accounts, Games}
+alias FungusToast.{Accounts}
 alias FungusToast.Skills.SkillsSeed
 alias FungusToast.Accounts.UsersSeed
 

--- a/test/fungus_toast/games/cell_grower_test.exs
+++ b/test/fungus_toast/games/cell_grower_test.exs
@@ -1,6 +1,6 @@
 defmodule FungusToast.Games.CellGrowerTest do
     use ExUnit.Case, async: true
-    alias FungusToast.Games.{CellGrower, GridCell, Player}
+    alias FungusToast.Games.{CellGrower, GridCell}
 
     doctest FungusToast.Games.CellGrower
 

--- a/test/fungus_toast/games/games_test.exs
+++ b/test/fungus_toast/games/games_test.exs
@@ -429,7 +429,7 @@ defmodule FungusToast.GamesTest do
   end
 
   describe "spend_human_player_mutation_points/3" do
-    test "that an error is returned if too many points were attempted to be spent" do
+    test "that an error is returned if too many mutation points were attempted to be spent" do
       user = user_fixture(%{user_name: "user name"})
       game = Games.create_game(user.user_name, %{number_of_human_players: 1, number_of_ai_players: 0})
       player = hd(game.players)

--- a/test/fungus_toast/games/games_test.exs
+++ b/test/fungus_toast/games/games_test.exs
@@ -1,7 +1,7 @@
 defmodule FungusToast.GamesTest do
   use FungusToast.DataCase
 
-  alias FungusToast.{Accounts, Games, Players, Rounds, Skills, PlayerSkills, AiStrategies}
+  alias FungusToast.{Accounts, Games, Players, Rounds, Skills, ActiveSkills, PlayerSkills, AiStrategies}
   alias FungusToast.Games.{Game, GameState, Player, GridCell}
   alias FungusToast.Game.Status
 
@@ -437,9 +437,9 @@ defmodule FungusToast.GamesTest do
 
       #spend one too many points
       one_more_than_available_points = player.mutation_points + 1
-      upgrade_attrs = %{skill.id => %{"active_cell_changes" => [], "points_spent" => one_more_than_available_points}}
+      passive_skill_upgrades = %{skill.id => one_more_than_available_points}
 
-      result = Games.spend_human_player_mutation_points(player.id, game.id, upgrade_attrs)
+      result = Games.spend_human_player_mutation_points(player.id, game.id, passive_skill_upgrades)
 
       assert {error_illegal_number_of_points_spent} = result
     end
@@ -448,14 +448,14 @@ defmodule FungusToast.GamesTest do
       user = user_fixture(%{user_name: "user name"})
       game = Games.create_game(user.user_name, %{number_of_human_players: 1, number_of_ai_players: 0})
       player = hd(game.players)
-      skill = Skills.get_skill_by_name(AiStrategies.skill_name_hydrophilia)
-      illegal_number_of_active_skill_changes = skill.number_of_active_cell_changes + 1
+      active_skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
+      illegal_number_of_active_skill_changes = active_skill.number_of_toast_changes + 1
       too_many_active_skill_changes = Enum.map(1..illegal_number_of_active_skill_changes, fn x -> x end)
 
       #spend one too many points
-      upgrade_attrs = %{skill.id => %{"active_cell_changes" => too_many_active_skill_changes, "points_spent" => 1}}
+      active_skill_upgrades = %{active_skill.id => %{"active_cell_changes" => too_many_active_skill_changes, "points_spent" => 1}}
 
-      result = Games.spend_human_player_mutation_points(player.id, game.id, upgrade_attrs)
+      result = Games.spend_human_player_mutation_points(player.id, game.id, %{}, active_skill_upgrades)
 
       assert {error_illegal_active_cell_changes} = result
     end
@@ -468,9 +468,9 @@ defmodule FungusToast.GamesTest do
 
       #spend all but one point
       one_less_than_available_points = player.mutation_points - 1
-      upgrade_attrs = %{skill.id => %{"active_cell_changes" => [], "points_spent" => one_less_than_available_points}}
+      passive_skill_upgrades = %{skill.id => one_less_than_available_points}
 
-      result = Games.spend_human_player_mutation_points(player.id, game.id, upgrade_attrs)
+      result = Games.spend_human_player_mutation_points(player.id, game.id, passive_skill_upgrades)
 
       assert {:ok, next_round_available: next_round_available, updated_player: updated_player} = result
       #since not all points were spent this should be false
@@ -494,9 +494,9 @@ defmodule FungusToast.GamesTest do
 
       #spend all of the first player's points
       starting_mutation_points = human_player.mutation_points
-      upgrade_attrs = %{skill.id => %{"active_cell_changes" => [], "points_spent" => starting_mutation_points}}
+      passive_skill_upgrades = %{skill.id => starting_mutation_points}
 
-      result = Games.spend_human_player_mutation_points(human_player.id, game.id, upgrade_attrs)
+      result = Games.spend_human_player_mutation_points(human_player.id, game.id, passive_skill_upgrades)
 
       assert {:ok, next_round_available: next_round_available, updated_player: _} = result
       #another player hasn't spent all their points so the next round shouldn't be available
@@ -511,8 +511,8 @@ defmodule FungusToast.GamesTest do
 
       #spend all of the player's points
       starting_mutation_points = human_player.mutation_points
-      upgrade_attrs = %{skill.id => %{"active_cell_changes" => [], "points_spent" => starting_mutation_points}}
-      result = Games.spend_human_player_mutation_points(human_player.id, game.id, upgrade_attrs)
+      passive_skill_upgrades = %{skill.id => starting_mutation_points}
+      result = Games.spend_human_player_mutation_points(human_player.id, game.id, passive_skill_upgrades)
 
       #since all points were spent this should be true
       assert {:ok, next_round_available: next_round_available, updated_player: updated_player} = result
@@ -524,7 +524,6 @@ defmodule FungusToast.GamesTest do
       assert player_skill.skill_level == starting_mutation_points
     end
 
-
     test "that when the next round is triggered AI players automatically spend their points" do
       user = user_fixture(%{user_name: "user name"})
       game = Games.create_game(user.user_name, %{number_of_human_players: 1, number_of_ai_players: 1})
@@ -533,9 +532,9 @@ defmodule FungusToast.GamesTest do
 
       #spend all of the player's points
       starting_mutation_points = human_player.mutation_points
-      upgrade_attrs = %{skill.id => %{"active_cell_changes" => [], "points_spent" => starting_mutation_points}}
+      passive_skill_upgrades = %{skill.id => starting_mutation_points}
 
-      result = Games.spend_human_player_mutation_points(human_player.id, game.id, upgrade_attrs)
+      result = Games.spend_human_player_mutation_points(human_player.id, game.id, passive_skill_upgrades)
 
       assert {:ok, next_round_available: next_round_available, updated_player: _} = result
       #since all points were spent this should be true

--- a/test/fungus_toast/games/grid_test.exs
+++ b/test/fungus_toast/games/grid_test.exs
@@ -67,28 +67,34 @@ defmodule FungusToast.Games.GridTest do
       growth_cycles = result.growth_cycles
       assert Enum.count(growth_cycles) == 6
 
-      assert has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 1, player1.id)
-      assert has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 2, player1.id)
-      assert has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 3, player1.id)
-      assert has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 4, player1.id)
-      assert has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 5, player1.id)
+      assert_has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 1, player1.id, true)
+      assert_has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 2, player1.id)
+      assert_has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 3, player1.id)
+      assert_has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 4, player1.id)
+      assert_has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, 5, player1.id)
       assert result.new_game_state
       assert length(result.new_game_state) == 1
     end
 
     test "conflicting toast changes will go to the first player that grew into the cell" do
-      #XXXXXX
+      #TODO FINISH THIS
     end
 
-    defp has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, generation_number, player_id) do
+    defp assert_has_growth_cycle_with_specified_generation_number_and_at_least_one_mutation_point(growth_cycles, generation_number, player_id, should_have_action_points \\ false) do
       growth_cycle = Enum.find(growth_cycles, fn growth_cycle -> growth_cycle.generation_number == generation_number end)
 
-      points_earned_map = Enum.into(growth_cycle.mutation_points_earned, %{},
+      mutation_points_earned_map = Enum.into(growth_cycle.mutation_points_earned, %{},
         fn mutation_points_earned -> {mutation_points_earned.player_id, mutation_points_earned.points} end)
-      if(growth_cycle != nil and points_earned_map[player_id] > 0) do
-        true
-      else
-        false
+
+      if(growth_cycle == nil and mutation_points_earned_map[player_id] == 0) do
+        assert false
+      end
+
+
+      action_points_earned_map = Enum.into(growth_cycle.action_points_earned, %{},
+        fn action_points_earned -> {action_points_earned.player_id, action_points_earned.points} end)
+      if(growth_cycle == nil and action_points_earned_map[player_id] == 0) do
+        refute should_have_action_points
       end
     end
 

--- a/test/fungus_toast/games/grid_test.exs
+++ b/test/fungus_toast/games/grid_test.exs
@@ -84,7 +84,7 @@ defmodule FungusToast.Games.GridTest do
       growth_cycle = Enum.find(growth_cycles, fn growth_cycle -> growth_cycle.generation_number == generation_number end)
 
       points_earned_map = Enum.into(growth_cycle.mutation_points_earned, %{},
-        fn mutation_points_earned -> {mutation_points_earned.player_id, mutation_points_earned.mutation_points} end)
+        fn mutation_points_earned -> {mutation_points_earned.player_id, mutation_points_earned.points} end)
       if(growth_cycle != nil and points_earned_map[player_id] > 0) do
         true
       else
@@ -182,7 +182,7 @@ defmodule FungusToast.Games.GridTest do
       growth_cycle = Enum.at(growth_cycles, 1)
 
       points_earned_map = Enum.into(growth_cycle.mutation_points_earned, %{},
-        fn mutation_points_earned -> {mutation_points_earned.player_id, mutation_points_earned.mutation_points} end)
+        fn mutation_points_earned -> {mutation_points_earned.player_id, mutation_points_earned.points} end)
       assert points_earned_map[player_1.id] > 1
       assert points_earned_map[player_2.id] > 1
       assert points_earned_map[player_3.id] > 1

--- a/test/fungus_toast/games/grid_test.exs
+++ b/test/fungus_toast/games/grid_test.exs
@@ -205,14 +205,14 @@ defmodule FungusToast.Games.GridTest do
       %Player{id: id, mutation_chance: 100}
     end
 
-    test "that it applies hydrophilia active cell changes to the starting game state before applying additional growth" do
+    test "that it applies eye dropper active cell changes to the starting game state before applying additional growth" do
       player1 = %Player{id: 1, top_growth_chance: 0, right_growth_chance: 0, bottom_growth_chance: 0, left_growth_chance: 0, mutation_chance: 0}
       player_id_to_player_map = %{player1.id => player1}
       grid_size = 50
       starting_grid = Grid.create_starting_grid(grid_size, [player1.id])
       starting_grid_map = Enum.into(starting_grid, %{}, fn grid_cell -> {grid_cell.index, grid_cell} end)
       expected_cell_indexes = [0, 1, 2]
-      active_cell_changes = [%ActiveCellChange{skill_id: Skills.skill_id_hydrophilia(), cell_indexes: expected_cell_indexes}]
+      active_cell_changes = [%ActiveCellChange{skill_id: Skills.skill_id_eye_dropper(), cell_indexes: expected_cell_indexes}]
 
       result = Grid.generate_growth_summary(starting_grid_map, active_cell_changes, grid_size, player_id_to_player_map)
 

--- a/test/fungus_toast/games/grid_test.exs
+++ b/test/fungus_toast/games/grid_test.exs
@@ -1,7 +1,7 @@
 defmodule FungusToast.Games.GridTest do
   use ExUnit.Case, async: true
   alias FungusToast.Games.{Grid, GridCell, Player, GrowthCycle, ActiveCellChange}
-  alias FungusToast.Skills
+  alias FungusToast.ActiveSkills
 
   doctest FungusToast.Games.Grid
 
@@ -212,7 +212,7 @@ defmodule FungusToast.Games.GridTest do
       starting_grid = Grid.create_starting_grid(grid_size, [player1.id])
       starting_grid_map = Enum.into(starting_grid, %{}, fn grid_cell -> {grid_cell.index, grid_cell} end)
       expected_cell_indexes = [0, 1, 2]
-      active_cell_changes = [%ActiveCellChange{skill_id: Skills.skill_id_eye_dropper(), cell_indexes: expected_cell_indexes}]
+      active_cell_changes = [%ActiveCellChange{active_skill_id: ActiveSkills.skill_id_eye_dropper(), cell_indexes: expected_cell_indexes}]
 
       result = Grid.generate_growth_summary(starting_grid_map, active_cell_changes, grid_size, player_id_to_player_map)
 
@@ -236,15 +236,16 @@ defmodule FungusToast.Games.GridTest do
       end)
     end
 
-    test "that it raises if an active cell change is for a skill that doesn't support active changes" do
+    test "that it raises if an active cell change is for an invalid active skill id" do
       player1 = %Player{id: 1, top_growth_chance: 0, right_growth_chance: 0, bottom_growth_chance: 0, left_growth_chance: 0, mutation_chance: 0}
       player_id_to_player_map = %{player1.id => player1}
       grid_size = 50
       starting_grid = Grid.create_starting_grid(grid_size, [player1.id])
       starting_grid_map = Enum.into(starting_grid, %{}, fn grid_cell -> {grid_cell.index, grid_cell} end)
-      active_cell_changes = [%ActiveCellChange{skill_id: Skills.skill_id_budding(), cell_indexes: [0]}]
+      skill_id_that_isnt_active = -1
+      active_cell_changes = [%ActiveCellChange{active_skill_id: skill_id_that_isnt_active, cell_indexes: [0]}]
 
-      assert_raise RuntimeError, fn -> Grid.generate_growth_summary(starting_grid_map, active_cell_changes, grid_size, player_id_to_player_map) end
+      assert_raise KeyError, fn -> Grid.generate_growth_summary(starting_grid_map, active_cell_changes, grid_size, player_id_to_player_map) end
     end
   end
 

--- a/test/fungus_toast/games/growth_cycle_test.exs
+++ b/test/fungus_toast/games/growth_cycle_test.exs
@@ -2,11 +2,11 @@ defmodule FungusToast.Games.GrowthCycleTest do
   use ExUnit.Case, async: true
   alias FungusToast.Games.GrowthCycle
   alias FungusToast.Games.GridCell
-  alias FungusToast.Games.MutationPointsEarned
+  alias FungusToast.Games.PointsEarned
 
   describe "changeset/2" do
     test "a valid changeset" do
-        assert %{valid?: true} = GrowthCycle.changeset(%GrowthCycle{}, %{generation_number: 0, mutation_points_earned: [%MutationPointsEarned{}], toast_changes: [%GridCell{}]})
+        assert %{valid?: true} = GrowthCycle.changeset(%GrowthCycle{}, %{generation_number: 0, mutation_points_earned: [%PointsEarned{}], toast_changes: [%GridCell{}]})
     end
 
     #TODO I can't get required field validation to work and I don't know why!

--- a/test/fungus_toast/games/helpers/active_cell_changes_test.exs
+++ b/test/fungus_toast/games/helpers/active_cell_changes_test.exs
@@ -28,6 +28,8 @@ defmodule FungusToast.ActiveCellChangesTest do
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes, fn x -> x end)
       upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
       assert ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
+      updated_player = Players.get_player!(player.id)
+      assert updated_player.action_points == 0
     end
 
     test "it returns true when two action points are spent and two times the max cell changes are requested" do

--- a/test/fungus_toast/games/helpers/active_cell_changes_test.exs
+++ b/test/fungus_toast/games/helpers/active_cell_changes_test.exs
@@ -22,7 +22,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      skill = Skills.get_skill!(Skills.skill_id_hydrophilia())
+      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes, fn x -> x end)
       upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
       assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
@@ -32,7 +32,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      skill = Skills.get_skill!(Skills.skill_id_hydrophilia())
+      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes * 2, fn x -> x end)
       upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 2}}
       assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
@@ -44,7 +44,7 @@ defmodule FungusToast.ActiveCellChangesTest do
     end
 
     test "it returns false when there are more active cell changes than the max allowed for that skill" do
-      skill = Skills.get_skill!(Skills.skill_id_hydrophilia())
+      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
       list_with_one_too_many_changes = Enum.map(1..skill.number_of_active_cell_changes + 1, fn x -> x end)
       upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_one_too_many_changes, "points_spent" => 1}}
       refute ActiveCellChanges.update_active_cell_changes(-1, -1, upgrade_attrs)
@@ -55,7 +55,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
 
-      skill = Skills.get_skill!(Skills.skill_id_hydrophilia())
+      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes, fn x -> x end)
       upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
 
@@ -77,7 +77,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       existing_active_cell_changes = [%ActiveCellChange{skill_id: -1, player_id: -1, cell_indexes: [-1]}]
       Rounds.update_round(latest_round, %{active_cell_changes: existing_active_cell_changes})
 
-      skill = Skills.get_skill!(Skills.skill_id_hydrophilia())
+      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes, fn x -> x end)
       upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
 

--- a/test/fungus_toast/games/helpers/active_cell_changes_test.exs
+++ b/test/fungus_toast/games/helpers/active_cell_changes_test.exs
@@ -1,6 +1,6 @@
 defmodule FungusToast.ActiveCellChangesTest do
   use FungusToast.DataCase
-  alias FungusToast.{Games, Players, Skills, Rounds, ActiveCellChanges}
+  alias FungusToast.{Games, Players, ActiveSkills, Rounds, ActiveCellChanges}
   alias FungusToast.Games.ActiveCellChange
 
   doctest FungusToast.ActiveCellChanges
@@ -14,7 +14,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      upgrade_attrs = %{"1" => %{"active_cell_changes" => [], "points_spent" => 1}, "2" => %{"active_cell_changes" => [], "points_spent" => 1}}
+      upgrade_attrs = %{"1" => %{"active_cell_changes" => [], "points_spent" => 1}}
       assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
     end
 
@@ -22,8 +22,8 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
-      list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes, fn x -> x end)
+      skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
+      list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes, fn x -> x end)
       upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
       assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
     end
@@ -32,8 +32,8 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
-      list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes * 2, fn x -> x end)
+      skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
+      list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes * 2, fn x -> x end)
       upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 2}}
       assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
     end
@@ -44,8 +44,8 @@ defmodule FungusToast.ActiveCellChangesTest do
     end
 
     test "it returns false when there are more active cell changes than the max allowed for that skill" do
-      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
-      list_with_one_too_many_changes = Enum.map(1..skill.number_of_active_cell_changes + 1, fn x -> x end)
+      skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
+      list_with_one_too_many_changes = Enum.map(1..skill.number_of_toast_changes + 1, fn x -> x end)
       upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_one_too_many_changes, "points_spent" => 1}}
       refute ActiveCellChanges.update_active_cell_changes(-1, -1, upgrade_attrs)
     end
@@ -55,8 +55,8 @@ defmodule FungusToast.ActiveCellChangesTest do
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
 
-      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
-      list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes, fn x -> x end)
+      skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
+      list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes, fn x -> x end)
       upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
 
       assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
@@ -74,12 +74,12 @@ defmodule FungusToast.ActiveCellChangesTest do
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
       latest_round = Rounds.get_latest_round_for_game(game.id)
-      existing_active_cell_changes = [%ActiveCellChange{skill_id: -1, player_id: -1, cell_indexes: [-1]}]
+      existing_active_cell_changes = [%ActiveCellChange{active_skill_id: -1, player_id: -1, cell_indexes: [-1]}]
       Rounds.update_round(latest_round, %{active_cell_changes: existing_active_cell_changes})
 
-      skill = Skills.get_skill!(Skills.skill_id_eye_dropper())
-      list_with_max_allowed_changes = Enum.map(1..skill.number_of_active_cell_changes, fn x -> x end)
-      upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
+      active_skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
+      list_with_max_allowed_changes = Enum.map(1..active_skill.number_of_toast_changes, fn x -> x end)
+      upgrade_attrs = %{active_skill.id => %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
 
       assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
 

--- a/test/fungus_toast/games/helpers/active_cell_changes_test.exs
+++ b/test/fungus_toast/games/helpers/active_cell_changes_test.exs
@@ -1,65 +1,78 @@
 defmodule FungusToast.ActiveCellChangesTest do
   use FungusToast.DataCase
   alias FungusToast.{Games, Players, ActiveSkills, Rounds, ActiveCellChanges}
-  alias FungusToast.Games.ActiveCellChange
+  alias FungusToast.Games.{ActiveCellChange, Player}
 
   doctest FungusToast.ActiveCellChanges
 
   describe "update_active_cell_changes/3" do
     test "that it returns true when there was an empty map" do
-      assert ActiveCellChanges.update_active_cell_changes(-1, -1, %{})
+      assert ActiveCellChanges.update_active_cell_changes(%Player{}, -1, %{})
     end
 
     test "that it returns true when there are no active cell changes" do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
+      |> Players.update_player(%{action_points: 1})
       upgrade_attrs = %{"1" => %{"active_cell_changes" => [], "points_spent" => 1}}
-      assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
+      assert ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
     end
 
-    test "it returns true when the number of active cell changes is equal to the max allowed per point for that skill" do
+    test "it returns true when the number of active cell changes is equal to the max allowed per action point for that skill" do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
+      |> Players.update_player(%{action_points: 1})
       skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes, fn x -> x end)
       upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
-      assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
+      assert ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
     end
 
-    test "it returns true when two points are spent and two times the max is spent" do
+    test "it returns true when two action points are spent and two times the max cell changes are requested" do
+      user = Fixtures.Accounts.User.create!()
+      game = Games.create_game(user.user_name, %{number_of_human_players: 1})
+      player = hd(Players.list_players_for_game(game.id))
+      |> Players.update_player(%{action_points: 2})
+      skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
+      list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes * 2, fn x -> x end)
+      upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 2}}
+      assert ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
+    end
+
+    test "it returns false when the player doesn't have enough action points" do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
       skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
-      list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes * 2, fn x -> x end)
-      upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 2}}
-      assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
+      upgrade_attrs = %{skill.id=> %{"active_cell_changes" => [], "points_spent" => 1}}
+      refute ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
     end
 
     test "it returns false when there are active cell changes but no points are spent" do
       upgrade_attrs = %{1 => %{"active_cell_changes" => [1], "points_spent" => 0}}
-      refute ActiveCellChanges.update_active_cell_changes(-1, -1, upgrade_attrs)
+      refute ActiveCellChanges.update_active_cell_changes(%Player{}, -1, upgrade_attrs)
     end
 
     test "it returns false when there are more active cell changes than the max allowed for that skill" do
       skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
       list_with_one_too_many_changes = Enum.map(1..skill.number_of_toast_changes + 1, fn x -> x end)
       upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_one_too_many_changes, "points_spent" => 1}}
-      refute ActiveCellChanges.update_active_cell_changes(-1, -1, upgrade_attrs)
+      refute ActiveCellChanges.update_active_cell_changes(%Player{action_points: 1}, -1, upgrade_attrs)
     end
 
     test "it sets active cell changes on the latest round" do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
+      |> Players.update_player(%{action_points: 1})
 
       skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes, fn x -> x end)
       upgrade_attrs = %{skill.id => %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
 
-      assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
+      assert ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
 
       latest_round = Rounds.get_latest_round_for_game(game.id)
       assert latest_round.active_cell_changes
@@ -73,6 +86,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
+      |> Players.update_player(%{action_points: 1})
       latest_round = Rounds.get_latest_round_for_game(game.id)
       existing_active_cell_changes = [%ActiveCellChange{active_skill_id: -1, player_id: -1, cell_indexes: [-1]}]
       Rounds.update_round(latest_round, %{active_cell_changes: existing_active_cell_changes})
@@ -81,7 +95,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       list_with_max_allowed_changes = Enum.map(1..active_skill.number_of_toast_changes, fn x -> x end)
       upgrade_attrs = %{active_skill.id => %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
 
-      assert ActiveCellChanges.update_active_cell_changes(player.id, game.id, upgrade_attrs)
+      assert ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
 
       latest_round = Rounds.get_latest_round_for_game(game.id)
       assert latest_round.active_cell_changes

--- a/test/fungus_toast/games/helpers/active_cell_changes_test.exs
+++ b/test/fungus_toast/games/helpers/active_cell_changes_test.exs
@@ -14,7 +14,6 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      |> Players.update_player(%{action_points: 1})
       upgrade_attrs = %{"1" => %{"active_cell_changes" => [], "points_spent" => 1}}
       assert ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
     end
@@ -23,7 +22,6 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      |> Players.update_player(%{action_points: 1})
       skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes, fn x -> x end)
       upgrade_attrs = %{skill.id=> %{"active_cell_changes" => list_with_max_allowed_changes, "points_spent" => 1}}
@@ -48,7 +46,7 @@ defmodule FungusToast.ActiveCellChangesTest do
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
       skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
-      upgrade_attrs = %{skill.id=> %{"active_cell_changes" => [], "points_spent" => 1}}
+      upgrade_attrs = %{skill.id=> %{"active_cell_changes" => [], "points_spent" => 2}}
       refute ActiveCellChanges.update_active_cell_changes(player, game.id, upgrade_attrs)
     end
 
@@ -68,7 +66,6 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      |> Players.update_player(%{action_points: 1})
 
       skill = ActiveSkills.get_active_skill!(ActiveSkills.skill_id_eye_dropper())
       list_with_max_allowed_changes = Enum.map(1..skill.number_of_toast_changes, fn x -> x end)
@@ -88,7 +85,6 @@ defmodule FungusToast.ActiveCellChangesTest do
       user = Fixtures.Accounts.User.create!()
       game = Games.create_game(user.user_name, %{number_of_human_players: 1})
       player = hd(Players.list_players_for_game(game.id))
-      |> Players.update_player(%{action_points: 1})
       latest_round = Rounds.get_latest_round_for_game(game.id)
       existing_active_cell_changes = [%ActiveCellChange{active_skill_id: -1, player_id: -1, cell_indexes: [-1]}]
       Rounds.update_round(latest_round, %{active_cell_changes: existing_active_cell_changes})

--- a/test/fungus_toast/games/helpers/ai_strategies_test.exs
+++ b/test/fungus_toast/games/helpers/ai_strategies_test.exs
@@ -15,6 +15,10 @@ defmodule FungusToast.Games.AiStrategiesTest do
       end)
     end
 
+    test "that it returns false if the skill can't max out (i.e. doesn't map to a player attribute)" do
+        refute AiStrategies.maxed_out_skill?(AiStrategies.skill_name_eye_dropper, %Player{})
+    end
+
     test "that it returns false when skills that bottom out at 0 are above 0" do
       Enum.each(AiStrategies.skills_that_bottom_out_at_0_percent, fn skill_name ->
         player = AiStrategies.get_player_attributes_for_skill_name(skill_name)

--- a/test/fungus_toast_web/views/game_view_test.exs
+++ b/test/fungus_toast_web/views/game_view_test.exs
@@ -200,11 +200,16 @@ defmodule FungusToastWeb.GameViewTest do
       player_2_mutation_points_earned = %PointsEarned{player_id: player_2_id, points: 30}
       mutation_points_earned = [player_1_mutation_points_earned, player_2_mutation_points_earned]
 
+      player_1_action_points_earned = %PointsEarned{player_id: player_1_id, points: 40}
+      player_2_action_points_earned = %PointsEarned{player_id: player_2_id, points: 50}
+      action_points_earned = [player_1_action_points_earned, player_2_action_points_earned]
+
       growth_cycle_1 = %GrowthCycle
       {
         generation_number: 1,
         toast_changes: growth_cycle_1_toast_changes,
         mutation_points_earned: mutation_points_earned,
+        action_points_earned: action_points_earned,
         player_stats_changes: player_stats_changes
       }
 
@@ -252,6 +257,10 @@ defmodule FungusToastWeb.GameViewTest do
       actual_mutation_points_earned = actual_growth_cycle_1.mutation_points_earned
       assert actual_mutation_points_earned[player_1_mutation_points_earned.player_id] == player_1_mutation_points_earned.points
       assert actual_mutation_points_earned[player_2_mutation_points_earned.player_id] == player_2_mutation_points_earned.points
+
+      actual_action_points_earned = actual_growth_cycle_1.action_points_earned
+      assert actual_action_points_earned[player_1_action_points_earned.player_id] == player_1_action_points_earned.points
+      assert actual_action_points_earned[player_2_action_points_earned.player_id] == player_2_action_points_earned.points
 
       actual_growth_cycle_2 = Enum.at(actual_growth_cycles, 1)
       actual_growth_cycle_2_toast_changes = actual_growth_cycle_2.toast_changes

--- a/test/fungus_toast_web/views/game_view_test.exs
+++ b/test/fungus_toast_web/views/game_view_test.exs
@@ -16,6 +16,7 @@ defmodule FungusToastWeb.GameViewTest do
         name: "player name",
         id: 1,
         mutation_points: 2,
+        action_points: 20,
         human: true,
         top_left_growth_chance: 3,
         top_growth_chance: 4,
@@ -67,6 +68,8 @@ defmodule FungusToastWeb.GameViewTest do
       actual_player_1_info = Enum.filter(result.players, fn player -> player.id == player_1.id end) |> hd
 
       assert actual_player_1_info.id == player_1.id
+      assert actual_player_1_info.mutation_points == player_1.mutation_points
+      assert actual_player_1_info.action_points == player_1.action_points
       assert actual_player_1_info.top_left_growth_chance == player_1.top_left_growth_chance
       assert actual_player_1_info.top_growth_chance == player_1.top_growth_chance
       assert actual_player_1_info.top_right_growth_chance == player_1.top_right_growth_chance

--- a/test/fungus_toast_web/views/game_view_test.exs
+++ b/test/fungus_toast_web/views/game_view_test.exs
@@ -2,7 +2,7 @@ defmodule FungusToastWeb.GameViewTest do
   use FungusToastWeb.ConnCase, async: true
   use Plug.Test
   alias FungusToastWeb.GameView
-  alias FungusToast.Games.{Game, Player, GridCell, GameState, Round, GrowthCycle, MutationPointsEarned, PlayerStatsChange, PlayerStats}
+  alias FungusToast.Games.{Game, Player, GridCell, GameState, Round, GrowthCycle, PointsEarned, PlayerStatsChange, PlayerStats}
   alias FungusToast.Game.Status
 
   import FungusToast.Factory
@@ -196,8 +196,8 @@ defmodule FungusToastWeb.GameViewTest do
       player_2_player_stats_change = %PlayerStatsChange{ player_id: player_2_id }
       player_stats_changes = [player_1_player_stats_change, player_2_player_stats_change]
 
-      player_1_mutation_points_earned = %MutationPointsEarned{player_id: player_1_id, mutation_points: 20}
-      player_2_mutation_points_earned = %MutationPointsEarned{player_id: player_2_id, mutation_points: 30}
+      player_1_mutation_points_earned = %PointsEarned{player_id: player_1_id, points: 20}
+      player_2_mutation_points_earned = %PointsEarned{player_id: player_2_id, points: 30}
       mutation_points_earned = [player_1_mutation_points_earned, player_2_mutation_points_earned]
 
       growth_cycle_1 = %GrowthCycle
@@ -250,8 +250,8 @@ defmodule FungusToastWeb.GameViewTest do
       assert actual_player_stats_changes[player_2_player_stats_change.player_id] == player_2_player_stats_change
 
       actual_mutation_points_earned = actual_growth_cycle_1.mutation_points_earned
-      assert actual_mutation_points_earned[player_1_mutation_points_earned.player_id] == player_1_mutation_points_earned.mutation_points
-      assert actual_mutation_points_earned[player_2_mutation_points_earned.player_id] == player_2_mutation_points_earned.mutation_points
+      assert actual_mutation_points_earned[player_1_mutation_points_earned.player_id] == player_1_mutation_points_earned.points
+      assert actual_mutation_points_earned[player_2_mutation_points_earned.player_id] == player_2_mutation_points_earned.points
 
       actual_growth_cycle_2 = Enum.at(actual_growth_cycles, 1)
       actual_growth_cycle_2_toast_changes = actual_growth_cycle_2.toast_changes

--- a/test/fungus_toast_web/views/skill_view_test.exs
+++ b/test/fungus_toast_web/views/skill_view_test.exs
@@ -10,7 +10,8 @@ defmodule FungusToastWeb.SkillViewTest do
         id: 1,
         name: "some name",
         up_is_good: true,
-        increase_per_point: 3.14
+        increase_per_point: 3.14,
+        minimum_round: 20
       }
 
       result = SkillView.render("skill.json", %{skill: skill})
@@ -19,6 +20,7 @@ defmodule FungusToastWeb.SkillViewTest do
       assert result.name == skill.name
       assert result.up_is_good == skill.up_is_good
       assert result.increase_per_point == skill.increase_per_point
+      assert result.minimum_round == skill.minimum_round
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,5 +2,5 @@
 ExUnit.start(exclude: [:skip])
 Ecto.Adapters.SQL.Sandbox.mode(FungusToast.Repo, {:shared, self()})
 
-FungusToast.Skills.SkillsSeed.seed_skills()
+FungusToast.Skills.SkillsSeed.reset_skills_in_database()
 


### PR DESCRIPTION
Passive skills require mutation points. Exactly one active skill "action point" must be used each turn.